### PR TITLE
upgrade golang to 1.12.8 in scripts & CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.12.x
 
 go_import_path: github.com/kinvolk/flatcar-linux-update-operator
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,6 @@ node('docker') {
     checkout scm
   }
   stage('Test') {
-    sh "docker run --rm -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/go/src/github.com/kinvolk/flatcar-linux-update-operator -w /go/src/github.com/kinvolk/flatcar-linux-update-operator golang:1.8.4 make all test"
+    sh "docker run --rm -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/go/src/github.com/kinvolk/flatcar-linux-update-operator -w /go/src/github.com/kinvolk/flatcar-linux-update-operator golang:1.12.8 make all test"
   }
 }

--- a/build/build-image.sh
+++ b/build/build-image.sh
@@ -10,7 +10,7 @@ readonly VERSION=${VERSION:-$(${REPO_ROOT}/build/git-version.sh)}
 sudo rkt run --uuid-file-save=rkt.uuid \
     --volume repo-root,kind=host,source=${REPO_ROOT} \
     --mount volume=repo-root,target=/go/src/github.com/kinvolk/flatcar-linux-update-operator \
-    --insecure-options=image,ondisk docker://golang:1.8.4 --exec /bin/bash -- -c \
+    --insecure-options=image,ondisk docker://golang:1.12.8 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kinvolk/flatcar-linux-update-operator && make clean test all"
 
 sudo rkt rm --uuid-file=rkt.uuid

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -7,7 +7,7 @@ readonly REPO_ROOT=$(git rev-parse --show-toplevel)
 sudo rkt run --uuid-file-save=rkt.uuid \
     --volume repo-root,kind=host,source=${REPO_ROOT} \
     --mount volume=repo-root,target=/go/src/github.com/kinvolk/flatcar-linux-update-operator \
-    --insecure-options=image,ondisk docker://golang:1.8.4 --exec /bin/bash -- -c \
+    --insecure-options=image,ondisk docker://golang:1.12.8 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kinvolk/flatcar-linux-update-operator && make clean test all"
 
 sudo rkt rm --uuid-file=rkt.uuid


### PR DESCRIPTION
To be up-to-date with recent versions, upgrade golang to 1.12.8.