### PR TITLE
examples/deploy: make it compatible with Kubernetes 1.17

### DIFF
--- a/examples/deploy/rbac/cluster-role-binding.yaml
+++ b/examples/deploy/rbac/cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flatcar-linux-update-operator
 roleRef:

--- a/examples/deploy/rbac/cluster-role.yaml
+++ b/examples/deploy/rbac/cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: flatcar-linux-update-operator

--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -8,6 +8,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: flatcar-linux-update-agent
   template:
     metadata:
       labels:

--- a/examples/deploy/update-agent.yaml
+++ b/examples/deploy/update-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: flatcar-linux-update-agent

--- a/examples/deploy/update-agent.yaml.tmpl
+++ b/examples/deploy/update-agent.yaml.tmpl
@@ -8,6 +8,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: flatcar-linux-update-agent
   template:
     metadata:
       labels:

--- a/examples/deploy/update-agent.yaml.tmpl
+++ b/examples/deploy/update-agent.yaml.tmpl
@@ -13,6 +13,7 @@ spec:
       labels:
         app: flatcar-linux-update-agent
     spec:
+      serviceAccountName: flatcar-linux-update-operator-sa
       containers:
       - name: update-agent
         image: quay.io/kinvolk/flatcar-linux-update-operator:v${VERSION}
@@ -21,12 +22,16 @@ spec:
         volumeMounts:
           - mountPath: /var/run/dbus
             name: var-run-dbus
+            readOnly: false
           - mountPath: /etc/flatcar
             name: etc-flatcar
+            readOnly: true
           - mountPath: /usr/share/flatcar
             name: usr-share-flatcar
+            readOnly: true
           - mountPath: /etc/os-release
             name: etc-os-release
+            readOnly: true
         env:
         # read by update-agent as the node name to manage reboots for
         - name: UPDATE_AGENT_NODE

--- a/examples/deploy/update-agent.yaml.tmpl
+++ b/examples/deploy/update-agent.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: flatcar-linux-update-agent

--- a/examples/deploy/update-operator.yaml
+++ b/examples/deploy/update-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flatcar-linux-update-operator

--- a/examples/deploy/update-operator.yaml
+++ b/examples/deploy/update-operator.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: reboot-coordinator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: flatcar-linux-update-operator
   template:
     metadata:
       labels:

--- a/examples/deploy/update-operator.yaml.tmpl
+++ b/examples/deploy/update-operator.yaml.tmpl
@@ -10,6 +10,7 @@ spec:
       labels:
         app: flatcar-linux-update-operator
     spec:
+      serviceAccountName: flatcar-linux-update-operator-sa
       containers:
       - name: update-operator
         image: quay.io/kinvolk/flatcar-linux-update-operator:v${VERSION}

--- a/examples/deploy/update-operator.yaml.tmpl
+++ b/examples/deploy/update-operator.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flatcar-linux-update-operator

--- a/examples/deploy/update-operator.yaml.tmpl
+++ b/examples/deploy/update-operator.yaml.tmpl
@@ -5,6 +5,9 @@ metadata:
   namespace: reboot-coordinator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: flatcar-linux-update-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
Trivial update to use a new API version `rbac.authorization.k8s.io/v1` in the example yaml files.

Also update the templates to make them match with actual yaml files.
So far service accounts and read only mounts were not updated to the yaml template files.
