### PR TITLE
upgrade Go to 1.13.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 go_import_path: github.com/kinvolk/flatcar-linux-update-operator
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,6 @@ node('docker') {
     checkout scm
   }
   stage('Test') {
-    sh "docker run --rm -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/go/src/github.com/kinvolk/flatcar-linux-update-operator -w /go/src/github.com/kinvolk/flatcar-linux-update-operator golang:1.12.8 make all test"
+    sh "docker run --rm -u \"\$(id -u):\$(id -g)\" -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v \"\$PWD\":/go/src/github.com/kinvolk/flatcar-linux-update-operator -w /go/src/github.com/kinvolk/flatcar-linux-update-operator golang:1.13.1 make all test"
   }
 }

--- a/build/build-image.sh
+++ b/build/build-image.sh
@@ -10,7 +10,7 @@ readonly VERSION=${VERSION:-$(${REPO_ROOT}/build/git-version.sh)}
 sudo rkt run --uuid-file-save=rkt.uuid \
     --volume repo-root,kind=host,source=${REPO_ROOT} \
     --mount volume=repo-root,target=/go/src/github.com/kinvolk/flatcar-linux-update-operator \
-    --insecure-options=image,ondisk docker://golang:1.12.8 --exec /bin/bash -- -c \
+    --insecure-options=image,ondisk docker://golang:1.13.1 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kinvolk/flatcar-linux-update-operator && make clean test all"
 
 sudo rkt rm --uuid-file=rkt.uuid

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -7,7 +7,7 @@ readonly REPO_ROOT=$(git rev-parse --show-toplevel)
 sudo rkt run --uuid-file-save=rkt.uuid \
     --volume repo-root,kind=host,source=${REPO_ROOT} \
     --mount volume=repo-root,target=/go/src/github.com/kinvolk/flatcar-linux-update-operator \
-    --insecure-options=image,ondisk docker://golang:1.12.8 --exec /bin/bash -- -c \
+    --insecure-options=image,ondisk docker://golang:1.13.1 --exec /bin/bash -- -c \
     "cd /go/src/github.com/kinvolk/flatcar-linux-update-operator && make clean test all"
 
 sudo rkt rm --uuid-file=rkt.uuid


### PR DESCRIPTION
To fix security issues in Go, [CVE-2019-16276](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16276), we should upgrade Go to 1.13.1.

See also https://github.com/golang/go/issues/34540