### PR TITLE
Build both binaries and include update-operator in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ WORKDIR /go/src/github.com/kinvolk/flatcar-linux-update-operator
 
 COPY . .
 
-RUN make bin/update-agent
+RUN make all
 
 FROM alpine:3.10
 MAINTAINER Kinvolk
 
 RUN apk add -U ca-certificates
 COPY --from=builder /go/src/github.com/kinvolk/flatcar-linux-update-operator/bin/update-agent /bin/
+COPY --from=builder /go/src/github.com/kinvolk/flatcar-linux-update-operator/bin/update-operator /bin/
 
 USER nobody
 


### PR DESCRIPTION
Running the operator fails due to the binary missing from the image.