### PR TITLE
Dockerfile: use numeric UID/GID for USER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN apk add -U ca-certificates
 COPY --from=builder /go/src/github.com/kinvolk/flatcar-linux-update-operator/bin/update-agent /bin/
 COPY --from=builder /go/src/github.com/kinvolk/flatcar-linux-update-operator/bin/update-operator /bin/
 
-USER nobody
+USER 65534:65534
 
 ENTRYPOINT ["/bin/update-agent"]


### PR DESCRIPTION
This makes this image to work with PSP, which specifies
MustRunAsNonRoot.

Kubernetes gives following error right now with such PSP, if Pod does
not have 'runAsUser' defined:

Error: container has runAsNonRoot and image has non-numeric user
(nobody), cannot verify user is non-root

The GID must be specified as well, as otherwise Docker will set it to
'root' automatically, according to the documentation:
https://docs.docker.com/engine/reference/builder/#user

This is also considered as a Docker best practice:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user

To verify that, pod should be run with PSP, which includes following
snippet:

```
runAsUser:
  rule: 'MustRunAsNonRoot'
```

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>