### PR TITLE
Makefile: don't run release-bin when building image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ release-bin:
 test:
 	go test -v $(REPO)/pkg/...
 
-image: release-bin
+image:
 	@$(DOCKER_CMD) build --rm=true -t $(IMAGE_REPO):$(VERSION) .
 
 image-push: image


### PR DESCRIPTION
The binaries are now built inside the image, so there is no need to
build them locally.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>