### PR TITLE
Replace 'Flatcar Linux' with 'Flatcar Container Linux'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flatcar Linux Update Operator
 
 Flatcar Linux Update Operator is a node reboot controller for Kubernetes running
-Flatcar Linux images. When a reboot is needed after updating the system via
+Flatcar Container Linux images. When a reboot is needed after updating the system via
 [update_engine](https://github.com/coreos/update_engine), the operator will
 drain the node before rebooting it.
 
@@ -24,7 +24,7 @@ Currently, `update-operator` only reboots one node at a time.
 
 ## Requirements
 
-- A Kubernetes cluster (>= 1.6) running on Flatcar Linux
+- A Kubernetes cluster (>= 1.6) running on Flatcar Container Linux
 - The `update-engine.service` systemd unit on each machine should be unmasked, enabled and started in systemd
 - The `locksmithd.service` systemd unit on each machine should be masked and stopped in systemd
 

--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -18,7 +18,7 @@ var (
 	beforeRebootAnnotations flagutil.StringSliceFlag
 	afterRebootAnnotations  flagutil.StringSliceFlag
 	kubeconfig              = flag.String("kubeconfig", "", "Path to a kubeconfig file. Default to the in-cluster config if not provided.")
-	autoLabelContainerLinux = flag.Bool("auto-label-flatcar-linux", false, "Auto-label Flatcar Linux nodes with agent=true (convenience)")
+	autoLabelContainerLinux = flag.Bool("auto-label-flatcar-linux", false, "Auto-label Flatcar Container Linux nodes with agent=true (convenience)")
 	rebootWindowStart       = flag.String("reboot-window-start", "", "Day of week ('Sun', 'Mon', ...; optional) and time of day at which the reboot window starts. E.g. 'Mon 14:00', '11:00'")
 	rebootWindowLength      = flag.String("reboot-window-length", "", "Length of the reboot window. E.g. '1h30m'")
 	printVersion            = flag.Bool("version", false, "Print version and exit")

--- a/doc/development.md
+++ b/doc/development.md
@@ -36,12 +36,12 @@ Switch your personal repository to be public so images can be pulled.
 
 ### Cluster
 
-Deploy a Flatcar Linux Kubernetes cluster that satisfies the [requirements](README.md#requirements).
+Deploy a Flatcar Container Linux Kubernetes cluster that satisfies the [requirements](README.md#requirements).
 
 * [QEMU/KVM](https://github.com/coreos/matchbox/tree/master/examples/terraform/bootkube-install)
 * [Tectonic](https://github.com/coreos/tectonic-installer)
 
-In particular, be sure to mask `locksmithd.service` on every Flatcar Linux node.
+In particular, be sure to mask `locksmithd.service` on every Flatcar Container Linux node.
 
 ```
 sudo systemctl mask locksmithd.service --now
@@ -84,14 +84,14 @@ I0622 20:06:09.017977       1 agent.go:211] Beginning to watch update_engine sta
 I0622 20:06:09.023410       1 agent.go:68] Updating status
 ```
 
-Send a fake 'need reboot' signal, as though `update-engine.service` had requested a reboot or actually check for a Flatcar Linux update (if cluster was deployed with older version).
+Send a fake 'need reboot' signal, as though `update-engine.service` had requested a reboot or actually check for a Flatcar Container Linux update (if cluster was deployed with older version).
 
 ```sh
 $ ssh core@node.example.com
 $ locksmithctl send-need-reboot
 ```
 
-Alternately, check for a Flatcar Linux update if the cluster was deployed with an older version of Flatcar Linux.
+Alternately, check for a Flatcar Container Linux update if the cluster was deployed with an older version of Flatcar Container Linux.
 
 ```sh
 $ ssh core@node.example.com

--- a/doc/labels-and-annotations.md
+++ b/doc/labels-and-annotations.md
@@ -10,7 +10,7 @@ A few labels may be set directly by admins to customize behavior. These are call
 
 | name  | example    | setter | description |
 |-------|------------|--------|---------------|
-| agent | true/false | admin, update-operator | When the `auto-label-flatcar-linux` compatability mode is enabled (via flag), the `update-operator` sets agent true on Flatcar Linux nodes. This is a convenient label that users may node selector upon, if desired. |
+| agent | true/false | admin, update-operator | When the `auto-label-flatcar-linux` compatability mode is enabled (via flag), the `update-operator` sets agent true on Flatcar Container Linux nodes. This is a convenient label that users may node selector upon, if desired. |
 | before-reboot | true | update-operator | The `update-operator` sets the `before-reboot` label when a machine want to reboot. It signifies that the before-reboot checks should run on the node, if there are any. |
 | after-reboot | true | update-operator | The `update-operator` sets the `after-reboot` label when a machine has completed it's reboot. It signifies that the after-reboot checks should run on the node, if there are any. |
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -263,7 +263,7 @@ func (k *Klocksmith) updateStatusCallback(s updateengine.Status) {
 	}, wait.NeverStop)
 }
 
-// setInfoLabels labels our node with helpful info about Flatcar Linux.
+// setInfoLabels labels our node with helpful info about Flatcar Container Linux.
 func (k *Klocksmith) setInfoLabels() error {
 	vi, err := k8sutil.GetVersionInfo()
 	if err != nil {

--- a/pkg/k8sutil/selector.go
+++ b/pkg/k8sutil/selector.go
@@ -47,14 +47,15 @@ func FilterNodesByRequirement(nodes []v1api.Node, req *labels.Requirement) []v1a
 }
 
 // FilterContainerLinuxNodes filters a list of nodes and returns nodes with a
-// Flatcar Linux OSImage, as reported by the node's /etc/os-release.
+// Flatcar Container Linux OSImage, as reported by the node's /etc/os-release.
 func FilterContainerLinuxNodes(nodes []v1api.Node) []v1api.Node {
 	var matches []v1api.Node
 
 	for _, node := range nodes {
-		if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Flatcar Linux") {
+		if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Flatcar Container Linux") {
 			matches = append(matches, node)
 		}
 	}
+
 	return matches
 }

--- a/pkg/operator/agent_manager.go
+++ b/pkg/operator/agent_manager.go
@@ -37,7 +37,7 @@ var (
 	)
 )
 
-// legacyLabeler finds Flatcar Linux nodes lacking the update-agent enabled
+// legacyLabeler finds Flatcar Container Linux nodes lacking the update-agent enabled
 // label and adds the label set "true" so nodes opt-in to running update-agent.
 //
 // Important: This behavior supports clusters which may have nodes that do not
@@ -46,7 +46,7 @@ var (
 // the label. Retain this behavior to support upgrades of Tectonic clusters
 // created at 1.6.
 func (k *Kontroller) legacyLabeler() {
-	glog.V(6).Infof("Starting Flatcar Linux node auto-labeler")
+	glog.V(6).Infof("Starting Flatcar Container Linux node auto-labeler")
 
 	nodelist, err := k.nc.List(v1meta.ListOptions{})
 	if err != nil {
@@ -56,9 +56,9 @@ func (k *Kontroller) legacyLabeler() {
 
 	// match nodes that don't have an update-agent label
 	nodesMissingLabel := k8sutil.FilterNodesByRequirement(nodelist.Items, updateAgentLabelMissing)
-	// match nodes that identify as Flatcar Linux
+	// match nodes that identify as Flatcar Container Linux
 	nodesToLabel := k8sutil.FilterContainerLinuxNodes(nodesMissingLabel)
-	glog.V(6).Infof("Found Flatcar Linux nodes to label: %+v", nodelist.Items)
+	glog.V(6).Infof("Found Flatcar Container Linux nodes to label: %+v", nodelist.Items)
 
 	for _, node := range nodesToLabel {
 		glog.Infof("Setting label 'agent=true' on %q", node.Name)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -101,7 +101,7 @@ type Kontroller struct {
 	// It will be set to the namespace the operator is running in automatically.
 	namespace string
 
-	// auto-label Flatcar Linux nodes for migration compatability
+	// auto-label Flatcar Container Linux nodes for migration compatability
 	autoLabelContainerLinux bool
 
 	// reboot window
@@ -201,7 +201,7 @@ func (k *Kontroller) Run(stop <-chan struct{}) error {
 		return err
 	}
 
-	// start Flatcar Linux node auto-labeler
+	// start Flatcar Container Linux node auto-labeler
 	if k.autoLabelContainerLinux {
 		go wait.Until(k.legacyLabeler, reconciliationPeriod, stop)
 	}


### PR DESCRIPTION
As this is official name we should be using where possible.

Name of the project stays as it is for now on to avoid confusion and
creating problems. Also FLUO sounds nicer than FCLUO.

This commit also changes FilterContainerLinuxNodes() function, which
selects Flatcar nodes from list of Kubernetes nodes based on osImage
field from nodeInfo, which is taken from PRETTY_NAME field in /etc/os-release
file on each node.

This field has been changed from 'Flatcar Linux' to 'Flatcar Container
Linux' in 2247.7.0 Flatcar version, which was released almost year ago,
so since then the function was broken.

As this change has been released upstream long time ago, it should be okay
to drop support for the old variant.

Closes #25
Closes #28

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>