### PR TITLE
Fix some of linter issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.3'
+          go-version: '1.15.4'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2
         with:
           go-version: '1.15.3'
         id: go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
     - ineffassign
     - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - nestif
@@ -77,3 +76,4 @@ linters:
     - godox
     - goerr113
     - exhaustivestruct
+    - maligned

--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -38,6 +38,7 @@ func main() {
 	}
 
 	rt := time.Duration(*reapTimeout) * time.Second
+
 	a, err := agent.New(*node, rt)
 	if err != nil {
 		klog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)

--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -102,7 +102,7 @@ func (o *optValue) Set(s string) error {
 	o.value = v
 	o.present = true
 
-	return err
+	return err //nolint:wrapcheck
 }
 
 func (o *optValue) String() string {

--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -101,6 +101,7 @@ func (o *optValue) Set(s string) error {
 	v, err := strconv.ParseBool(s)
 	o.value = v
 	o.present = true
+
 	return err
 }
 

--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -22,7 +22,7 @@ var (
 	rebootWindowStart       = flag.String("reboot-window-start", "", "Day of week ('Sun', 'Mon', ...; optional) and time of day at which the reboot window starts. E.g. 'Mon 14:00', '11:00'")
 	rebootWindowLength      = flag.String("reboot-window-length", "", "Length of the reboot window. E.g. '1h30m'")
 	printVersion            = flag.Bool("version", false, "Print version and exit")
-	// deprecated
+	// Deprecated flags.
 	analyticsEnabled optValue
 	manageAgent      = flag.Bool("manage-agent", false, "Manage the associated update-agent")
 	agentImageRepo   = flag.String("agent-image-repo", "quay.io/kinvolk/flatcar-linux-update-operator", "The image to use for the managed agent, without version tag")
@@ -45,7 +45,7 @@ func main() {
 		klog.Warning("Use of -analytics is deprecated and will be removed. Google Analytics will not be enabled.")
 	}
 
-	// respect KUBECONFIG without the prefix as well
+	// Respect KUBECONFIG without the prefix as well.
 	if *kubeconfig == "" {
 		*kubeconfig = os.Getenv("KUBECONFIG")
 	}
@@ -59,13 +59,13 @@ func main() {
 		klog.Warning("Use of -manage-agent=true is deprecated and will be removed in the future")
 	}
 
-	// create Kubernetes client (clientset)
+	// Create Kubernetes client (clientset).
 	client, err := k8sutil.GetClient(*kubeconfig)
 	if err != nil {
 		klog.Fatalf("Failed to create Kubernetes client: %v", err)
 	}
 
-	// update-operator
+	// Construct update-operator.
 	o, err := operator.New(operator.Config{
 		Client:                  client,
 		AutoLabelContainerLinux: *autoLabelContainerLinux,
@@ -82,7 +82,7 @@ func main() {
 
 	klog.Infof("%s running", os.Args[0])
 
-	// Run operator until the stop channel is closed
+	// Run operator until the stop channel is closed.
 	stop := make(chan struct{})
 	defer close(stop)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -94,7 +94,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 
 	node, err := k8sutil.GetNodeRetry(k.nc, k.node)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting node %q: %w", k.node, err)
 	}
 
 	// Only make a node schedulable if a reboot was in progress. This prevents a node from being made schedulable
@@ -115,7 +115,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 	klog.Infof("Setting annotations %#v", anno)
 
 	if err := k8sutil.SetNodeAnnotationsLabels(k.nc, k.node, anno, labels); err != nil {
-		return err
+		return fmt.Errorf("setting node %q labels and annotations: %w", k.node, err)
 	}
 
 	// Since we set 'reboot-needed=false', 'ok-to-reboot' should clear.
@@ -129,7 +129,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 		klog.Info("Marking node as schedulable")
 
 		if err := k8sutil.Unschedulable(k.nc, k.node, false); err != nil {
-			return err
+			return fmt.Errorf("marking node %q as unschedulable: %w", k.node, err)
 		}
 
 		anno = map[string]string{
@@ -139,7 +139,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 		klog.Infof("Setting annotations %#v", anno)
 
 		if err := k8sutil.SetNodeAnnotations(k.nc, k.node, anno); err != nil {
-			return err
+			return fmt.Errorf("setting node %q annotations: %w", k.node, err)
 		}
 	} else if madeUnschedulableAnnotationExists { // Annotation exists so node was marked unschedulable by external source.
 		klog.Info("Skipping marking node as schedulable -- node was marked unschedulable by an external source")
@@ -165,7 +165,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 
 	node, err = k8sutil.GetNodeRetry(k.nc, k.node)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting node %q: %w", k.node, err)
 	}
 
 	alreadyUnschedulable := node.Spec.Unschedulable
@@ -182,7 +182,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 	klog.Infof("Setting annotations %#v", anno)
 
 	if err := k8sutil.SetNodeAnnotations(k.nc, k.node, anno); err != nil {
-		return err
+		return fmt.Errorf("setting node %q annotations: %w", k.node, err)
 	}
 
 	// Drain self equates to:
@@ -196,7 +196,7 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 		klog.Info("Marking node as unschedulable")
 
 		if err := k8sutil.Unschedulable(k.nc, k.node, true); err != nil {
-			return err
+			return fmt.Errorf("marking node %q as unschedulable: %w", k.node, err)
 		}
 	} else {
 		klog.Info("Node already marked as unschedulable")
@@ -300,7 +300,7 @@ func (k *Klocksmith) setInfoLabels() error {
 	}
 
 	if err := k8sutil.SetNodeLabels(k.nc, k.node, labels); err != nil {
-		return err
+		return fmt.Errorf("setting node %q labels: %w", k.node, err)
 	}
 
 	return nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -411,11 +411,7 @@ func (k *Klocksmith) getPodsForDeletion() ([]corev1.Pod, error) {
 	// kube-controller-manager.
 
 	pods = k8sutil.FilterPods(pods, func(p *corev1.Pod) bool {
-		if p.Namespace == "kube-system" {
-			return false
-		}
-
-		return true
+		return p.Namespace != "kube-system"
 	})
 
 	return pods, nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,3 +1,7 @@
+// Package agent implements Flatcar Linux Update Operator agent, which role is to
+// run on every Flatcar Node on the cluster, watch update_engine for status updates,
+// propagate them to operator via Node labels and annotations and react on operator
+// decisions about when to drain a node and reboot to finish upgrade process.
 package agent
 
 import (

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kinvolk/flatcar-linux-update-operator/pkg/constants"
-	"github.com/kinvolk/flatcar-linux-update-operator/pkg/drain"
 	"github.com/kinvolk/flatcar-linux-update-operator/pkg/k8sutil"
 	"github.com/kinvolk/flatcar-linux-update-operator/pkg/updateengine"
 )
@@ -419,7 +418,7 @@ func (k *Klocksmith) waitForNotOkToReboot() error {
 }
 
 func (k *Klocksmith) getPodsForDeletion() ([]corev1.Pod, error) {
-	pods, err := drain.GetPodsForDeletion(k.kc, k.node)
+	pods, err := k8sutil.GetPodsForDeletion(k.kc, k.node)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list of pods for deletion: %v", err)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -3,31 +3,35 @@
 package constants
 
 const (
-	// Annotation values used by update-agent and update-operator
-	True  = "true"
+	// True is annotation value used by update-agent and update-operator.
+	True = "true"
+
+	// False is annotation value used by update-agent and update-operator.
 	False = "false"
 
 	// Prefix used by all label and annotation keys.
 	Prefix = "flatcar-linux-update.v1.flatcar-linux.net/"
 
-	// Key set to "true" by the update-agent when a reboot is requested.
+	// AnnotationRebootNeeded is a key set to "true" by the update-agent when a reboot is requested.
 	AnnotationRebootNeeded = Prefix + "reboot-needed"
-	LabelRebootNeeded      = Prefix + "reboot-needed"
 
-	// Key set to "true" by the update-agent when node-drain and reboot is
+	// LabelRebootNeeded is an label name set to "true" by the update-agent when a reboot is requested.
+	LabelRebootNeeded = Prefix + "reboot-needed"
+
+	// AnnotationRebootInProgress is a key set to "true" by the update-agent when node-drain and reboot is
 	// initiated.
 	AnnotationRebootInProgress = Prefix + "reboot-in-progress"
 
-	// Key set to "true" by the update-operator when an agent may proceed
+	// AnnotationOkToReboot is a key set to "true" by the update-operator when an agent may proceed
 	// with a node-drain and reboot.
 	AnnotationOkToReboot = Prefix + "reboot-ok"
 
-	// Key that may be set by the administrator to "true" to prevent
+	// AnnotationRebootPaused is a key that may be set by the administrator to "true" to prevent
 	// update-operator from considering a node for rebooting.  Never set by
 	// the update-agent or update-operator.
 	AnnotationRebootPaused = Prefix + "reboot-paused"
 
-	// Key set by the update-agent to the current operator status of update_agent.
+	// AnnotationStatus is a key set by the update-agent to the current operator status of update_agent.
 	//
 	// Possible values are:
 	//  - "UPDATE_STATUS_IDLE"
@@ -42,12 +46,13 @@ const (
 	// It is possible, but extremely unlike for it to be "unknown status".
 	AnnotationStatus = Prefix + "status"
 
-	// Key set by the update-agent to LAST_CHECKED_TIME reported by update_engine.
+	// AnnotationLastCheckedTime is a keyset by the update-agent to LAST_CHECKED_TIME reported
+	// by update_engine.
 	//
 	// It is zero if an update has never been checked for, or a UNIX timestamp.
 	AnnotationLastCheckedTime = Prefix + "last-checked-time"
 
-	// Key set by the update-agent to NEW_VERSION reported by update_engine.
+	// AnnotationNewVersion is a key set by the update-agent to NEW_VERSION reported by update_engine.
 	//
 	// It is an opaque string, but might be semver.
 	AnnotationNewVersion = Prefix + "new-version"
@@ -56,23 +61,26 @@ const (
 	// it was responsible for making node unschedulable.
 	AnnotationAgentMadeUnschedulable = Prefix + "agent-made-unschedulable"
 
-	// Keys set to true when the operator is waiting for configured annotation
+	// LabelBeforeReboot is a key set to true when the operator is waiting for configured annotation
 	// before and after the reboot respectively.
 	LabelBeforeReboot = Prefix + "before-reboot"
-	LabelAfterReboot  = Prefix + "after-reboot"
 
-	// Key set by the update-agent to the value of "ID" in /etc/os-release.
+	// LabelAfterReboot is a key set to true when the operator is waiting for configured annotation
+	// before and after the reboot respectively.
+	LabelAfterReboot = Prefix + "after-reboot"
+
+	// LabelID is a key set by the update-agent to the value of "ID" in /etc/os-release.
 	LabelID = Prefix + "id"
 
-	// Key set by the update-agent to the value of "GROUP" in
+	// LabelGroup is a key set by the update-agent to the value of "GROUP" in
 	// /usr/share/flatcar/update.conf, overridden by the value of "GROUP" in
 	// /etc/flatcar/update.conf.
 	LabelGroup = Prefix + "group"
 
-	// Key set by the update-agent to the value of "VERSION" in /etc/os-release.
+	// LabelVersion is a key set by the update-agent to the value of "VERSION" in /etc/os-release.
 	LabelVersion = Prefix + "version"
 
-	// Label set to "true" on nodes where update-agent pods should be scheduled.
+	// LabelUpdateAgentEnabled is a key set to "true" on nodes where update-agent pods should be scheduled.
 	// This applies only when update-operator is run with the flag
 	// auto-label-flatcar-linux=true
 	LabelUpdateAgentEnabled = Prefix + "agent"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,8 +81,7 @@ const (
 	LabelVersion = Prefix + "version"
 
 	// LabelUpdateAgentEnabled is a key set to "true" on nodes where update-agent pods should be scheduled.
-	// This applies only when update-operator is run with the flag
-	// auto-label-flatcar-linux=true
+	// This applies only when update-operator is run with the flag "auto-label-flatcar-linux=true".
 	LabelUpdateAgentEnabled = Prefix + "agent"
 
 	// AgentVersion is the key used to indicate the

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -28,7 +28,6 @@ func GetPodsForDeletion(kc kubernetes.Interface, node string) (pods []corev1.Pod
 	// exception, skip mirror pods and daemonset pods with an existing
 	// daemonset (since the daemonset owner would recreate them anyway).
 	for _, pod := range podList.Items {
-
 		// skip mirror pods
 		if _, ok := pod.Annotations[corev1.MirrorPodAnnotationKey]; ok {
 			continue
@@ -50,6 +49,7 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 	if len(pod.OwnerReferences) == 0 {
 		return nil, fmt.Errorf("pod %q has no owner objects", pod.Name)
 	}
+
 	for _, ownerRef := range pod.OwnerReferences {
 		// skip pod if it is owned by an existing daemonset
 		if ownerRef.Kind == "DaemonSet" {
@@ -58,6 +58,7 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 				// daemonset owner exists
 				return ds, nil
 			}
+
 			if !errors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to get controller of pod %q: %v", pod.Name, err)
 			}
@@ -75,5 +76,6 @@ func getDaemonsetController(kc kubernetes.Interface, namespace string, controlle
 	case "DaemonSet":
 		return kc.AppsV1().DaemonSets(namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
 	}
+
 	return nil, fmt.Errorf("Unknown controller kind %q", controllerRef.Kind)
 }

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -72,8 +72,7 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 //
 //nolint:lll
 func getDaemonsetController(kc kubernetes.Interface, namespace string, controllerRef *metav1.OwnerReference) (interface{}, error) {
-	switch controllerRef.Kind {
-	case "DaemonSet":
+	if controllerRef.Kind == "DaemonSet" {
 		return kc.AppsV1().DaemonSets(namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
 	}
 

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -51,9 +51,11 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 	}
 
 	for _, ownerRef := range pod.OwnerReferences {
+		ownerRef := ownerRef
+
 		// skip pod if it is owned by an existing daemonset
 		if ownerRef.Kind == "DaemonSet" {
-			ds, err := getDaemonsetController(kc, pod.Namespace, &ownerRef)
+			ds, err := getDaemonsetController(kc, pod.Namespace, ownerRef)
 			if err == nil {
 				// daemonset owner exists
 				return ds, nil
@@ -71,7 +73,7 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 // Stripped down version of https://github.com/kubernetes/kubernetes/blob/1bc56825a2dff06f29663a024ee339c25e6e6280/pkg/kubectl/cmd/drain.go#L272
 //
 //nolint:lll
-func getDaemonsetController(kc kubernetes.Interface, namespace string, controllerRef *metav1.OwnerReference) (interface{}, error) {
+func getDaemonsetController(kc kubernetes.Interface, namespace string, controllerRef metav1.OwnerReference) (interface{}, error) {
 	if controllerRef.Kind == "DaemonSet" {
 		return kc.AppsV1().DaemonSets(namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
 	}

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -13,7 +13,7 @@ import (
 func GetClient(path string) (*kubernetes.Clientset, error) {
 	conf, err := getClientConfig(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Kubernetes client config: %v", err)
+		return nil, fmt.Errorf("failed to get Kubernetes client config: %w", err)
 	}
 
 	return kubernetes.NewForConfig(conf)

--- a/pkg/k8sutil/client.go
+++ b/pkg/k8sutil/client.go
@@ -15,6 +15,7 @@ func GetClient(path string) (*kubernetes.Clientset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Kubernetes client config: %v", err)
 	}
+
 	return kubernetes.NewForConfig(conf)
 }
 

--- a/pkg/k8sutil/doc.go
+++ b/pkg/k8sutil/doc.go
@@ -1,0 +1,2 @@
+// Package k8sutil provides various wrappers over Kubernetes tooling.
+package k8sutil

--- a/pkg/k8sutil/drain.go
+++ b/pkg/k8sutil/drain.go
@@ -1,4 +1,4 @@
-package drain
+package k8sutil
 
 import (
 	"context"
@@ -78,5 +78,5 @@ func getDaemonsetController(kc kubernetes.Interface, namespace string, controlle
 		return kc.AppsV1().DaemonSets(namespace).Get(context.TODO(), controllerRef.Name, metav1.GetOptions{})
 	}
 
-	return nil, fmt.Errorf("Unknown controller kind %q", controllerRef.Kind)
+	return nil, fmt.Errorf("unknown controller kind %q", controllerRef.Kind)
 }

--- a/pkg/k8sutil/drain.go
+++ b/pkg/k8sutil/drain.go
@@ -62,7 +62,7 @@ func getOwnerDaemonset(kc kubernetes.Interface, pod corev1.Pod) (interface{}, er
 			}
 
 			if !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to get controller of pod %q: %v", pod.Name, err)
+				return nil, fmt.Errorf("failed to get controller of pod %q: %w", pod.Name, err)
 			}
 		}
 	}

--- a/pkg/k8sutil/drain.go
+++ b/pkg/k8sutil/drain.go
@@ -21,7 +21,7 @@ func GetPodsForDeletion(kc kubernetes.Interface, node string) (pods []corev1.Pod
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node}).String(),
 	})
 	if err != nil {
-		return pods, err
+		return nil, fmt.Errorf("listing pods on node %q: %w", node, err)
 	}
 
 	// Delete pods, even if they are lone pods without a controller. As an

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -71,7 +71,7 @@ func UpdateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 
 		_, err := nc.Update(context.TODO(), n, v1meta.UpdateOptions{})
 
-		return err
+		return err //nolint:wrapcheck
 	})
 	if err != nil {
 		// May be conflict if max retries were hit.
@@ -182,7 +182,7 @@ func getUpdateMap() (map[string]string, error) {
 	// This file should always be present on CoreOS.
 	uconf, err := os.Open(updateConfPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening file %q: %w", updateConfPath, err)
 	}
 
 	b, err := ioutil.ReadAll(uconf)
@@ -190,7 +190,7 @@ func getUpdateMap() (map[string]string, error) {
 	uconf.Close()
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading file %q: %w", updateConfPath, err)
 	}
 
 	splitNewlineEnv(infomap, string(b))
@@ -218,7 +218,7 @@ func getReleaseMap() (map[string]string, error) {
 	// This file should always be present on CoreOS.
 	osrelease, err := os.Open(osReleasePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening file %q: %w", osReleasePath, err)
 	}
 
 	defer osrelease.Close()
@@ -228,7 +228,7 @@ func getReleaseMap() (map[string]string, error) {
 	osrelease.Close()
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading file %q: %w", osReleasePath, err)
 	}
 
 	splitNewlineEnv(infomap, string(b))

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -37,7 +37,7 @@ func NodeAnnotationCondition(selector fields.Selector) watchtools.ConditionFunc 
 	}
 }
 
-// GetNodeRetry gets a node object, retrying up to DefaultBackoff number of times if it fails
+// GetNodeRetry gets a node object, retrying up to DefaultBackoff number of times if it fails.
 func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
 	var apiNode *v1api.Node
 
@@ -74,7 +74,7 @@ func UpdateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 		return err
 	})
 	if err != nil {
-		// may be conflict if max retries were hit
+		// May be conflict if max retries were hit.
 		return fmt.Errorf("unable to update node %q: %w", node, err)
 	}
 
@@ -102,7 +102,7 @@ func SetNodeAnnotations(nc v1core.NodeInterface, node string, m map[string]strin
 }
 
 // SetNodeAnnotationsLabels sets all keys in a and l to their values in
-// node's annotations and labels, respectively
+// node's annotations and labels, respectively.
 func SetNodeAnnotationsLabels(nc v1core.NodeInterface, node string, a, l map[string]string) error {
 	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
 		for k, v := range a {
@@ -115,7 +115,7 @@ func SetNodeAnnotationsLabels(nc v1core.NodeInterface, node string, a, l map[str
 	})
 }
 
-// DeleteNodeLabels deletes all keys in ks
+// DeleteNodeLabels deletes all keys in ks.
 func DeleteNodeLabels(nc v1core.NodeInterface, node string, ks []string) error {
 	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
 		for _, k := range ks {
@@ -124,7 +124,7 @@ func DeleteNodeLabels(nc v1core.NodeInterface, node string, ks []string) error {
 	})
 }
 
-// DeleteNodeAnnotations deletes all annotations with keys in ks
+// DeleteNodeAnnotations deletes all annotations with keys in ks.
 func DeleteNodeAnnotations(nc v1core.NodeInterface, node string, ks []string) error {
 	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
 		for _, k := range ks {
@@ -153,13 +153,13 @@ func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 	return nil
 }
 
-// splits newline-delimited KEY=VAL pairs and update map
+// splitNewlineEnv splits newline-delimited KEY=VAL pairs and update map.
 func splitNewlineEnv(m map[string]string, envs string) {
 	sc := bufio.NewScanner(strings.NewReader(envs))
 	for sc.Scan() {
 		spl := strings.SplitN(sc.Text(), "=", 2)
 
-		// just skip empty lines or lines without a value
+		// Just skip empty lines or lines without a value.
 		if len(spl) == 1 {
 			continue
 		}
@@ -179,7 +179,7 @@ type VersionInfo struct {
 func getUpdateMap() (map[string]string, error) {
 	infomap := map[string]string{}
 
-	// this file should always be present on CoreOS
+	// This file should always be present on CoreOS.
 	uconf, err := os.Open(updateConfPath)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func getUpdateMap() (map[string]string, error) {
 
 	splitNewlineEnv(infomap, string(b))
 
-	// if present and readable, this file has overrides
+	// If present and readable, this file has overrides.
 	econf, err := os.Open(updateConfOverridePath)
 	if err != nil {
 		klog.Infof("Skipping missing update.conf: %w", err)
@@ -215,7 +215,7 @@ func getUpdateMap() (map[string]string, error) {
 func getReleaseMap() (map[string]string, error) {
 	infomap := map[string]string{}
 
-	// this file should always be present on CoreOS
+	// This file should always be present on CoreOS.
 	osrelease, err := os.Open(osReleasePath)
 	if err != nil {
 		return nil, err

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -30,6 +30,7 @@ func NodeAnnotationCondition(selector fields.Selector) watchtools.ConditionFunc 
 		switch event.Type {
 		case watch.Modified:
 			node := event.Object.(*v1api.Node)
+
 			return selector.Matches(fields.Set(node.Annotations)), nil
 		}
 
@@ -40,6 +41,7 @@ func NodeAnnotationCondition(selector fields.Selector) watchtools.ConditionFunc 
 // GetNodeRetry gets a node object, retrying up to DefaultBackoff number of times if it fails
 func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
 	var apiNode *v1api.Node
+
 	err := RetryOnError(DefaultBackoff, func() error {
 		n, getErr := nc.Get(context.TODO(), node, v1meta.GetOptions{})
 		if getErr != nil {
@@ -47,6 +49,7 @@ func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
 		}
 
 		apiNode = n
+
 		return nil
 	})
 
@@ -68,6 +71,7 @@ func UpdateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 		f(n)
 
 		_, err := nc.Update(context.TODO(), n, v1meta.UpdateOptions{})
+
 		return err
 	})
 	if err != nil {
@@ -141,6 +145,7 @@ func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 
 	if err := RetryOnConflict(DefaultBackoff, func() (err error) {
 		n, err = nc.Update(context.TODO(), n, v1meta.UpdateOptions{})
+
 		return
 	}); err != nil {
 		return fmt.Errorf("unable to set 'Unschedulable' property of node %q to %t: %v", node, sched, err)
@@ -182,7 +187,9 @@ func getUpdateMap() (map[string]string, error) {
 	}
 
 	b, err := ioutil.ReadAll(uconf)
+
 	uconf.Close()
+
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +203,9 @@ func getUpdateMap() (map[string]string, error) {
 	}
 
 	b, err = ioutil.ReadAll(econf)
+
 	econf.Close()
+
 	if err == nil {
 		splitNewlineEnv(infomap, string(b))
 	}
@@ -214,8 +223,11 @@ func getReleaseMap() (map[string]string, error) {
 	}
 
 	defer osrelease.Close()
+
 	b, err := ioutil.ReadAll(osrelease)
+
 	osrelease.Close()
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -27,8 +27,7 @@ const (
 // node being watched has an annotation of key equal to value.
 func NodeAnnotationCondition(selector fields.Selector) watchtools.ConditionFunc {
 	return func(event watch.Event) (bool, error) {
-		switch event.Type {
-		case watch.Modified:
+		if event.Type == watch.Modified {
 			node := event.Object.(*v1api.Node)
 
 			return selector.Matches(fields.Set(node.Annotations)), nil

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -44,7 +44,7 @@ func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
 	err := RetryOnError(DefaultBackoff, func() error {
 		n, getErr := nc.Get(context.TODO(), node, v1meta.GetOptions{})
 		if getErr != nil {
-			return fmt.Errorf("failed to get node %q: %v", node, getErr)
+			return fmt.Errorf("failed to get node %q: %w", node, getErr)
 		}
 
 		apiNode = n
@@ -64,7 +64,7 @@ func UpdateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 	err := RetryOnConflict(DefaultBackoff, func() error {
 		n, getErr := nc.Get(context.TODO(), node, v1meta.GetOptions{})
 		if getErr != nil {
-			return fmt.Errorf("failed to get node %q: %v", node, getErr)
+			return fmt.Errorf("failed to get node %q: %w", node, getErr)
 		}
 
 		f(n)
@@ -75,7 +75,7 @@ func UpdateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 	})
 	if err != nil {
 		// may be conflict if max retries were hit
-		return fmt.Errorf("unable to update node %q: %v", node, err)
+		return fmt.Errorf("unable to update node %q: %w", node, err)
 	}
 
 	return nil
@@ -137,7 +137,7 @@ func DeleteNodeAnnotations(nc v1core.NodeInterface, node string, ks []string) er
 func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 	n, err := nc.Get(context.TODO(), node, v1meta.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get node %q: %v", node, err)
+		return fmt.Errorf("failed to get node %q: %w", node, err)
 	}
 
 	n.Spec.Unschedulable = sched
@@ -147,7 +147,7 @@ func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 
 		return
 	}); err != nil {
-		return fmt.Errorf("unable to set 'Unschedulable' property of node %q to %t: %v", node, sched, err)
+		return fmt.Errorf("unable to set 'Unschedulable' property of node %q to %t: %w", node, sched, err)
 	}
 
 	return nil
@@ -198,7 +198,7 @@ func getUpdateMap() (map[string]string, error) {
 	// if present and readable, this file has overrides
 	econf, err := os.Open(updateConfOverridePath)
 	if err != nil {
-		klog.Infof("Skipping missing update.conf: %v", err)
+		klog.Infof("Skipping missing update.conf: %w", err)
 	}
 
 	b, err = ioutil.ReadAll(econf)
@@ -242,12 +242,12 @@ func getReleaseMap() (map[string]string, error) {
 func GetVersionInfo() (*VersionInfo, error) {
 	updateconf, err := getUpdateMap()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get update configuration: %v", err)
+		return nil, fmt.Errorf("unable to get update configuration: %w", err)
 	}
 
 	osrelease, err := getReleaseMap()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get os release info: %v", err)
+		return nil, fmt.Errorf("unable to get os release info: %w", err)
 	}
 
 	vi := &VersionInfo{

--- a/pkg/k8sutil/metadata_test.go
+++ b/pkg/k8sutil/metadata_test.go
@@ -18,7 +18,9 @@ import (
 func atomicCounterIncrement(n *corev1.Node) {
 	counterAnno := "counter"
 	s := n.Annotations[counterAnno]
+
 	var i int
+
 	if s == "" {
 		i = 0
 	} else {
@@ -28,6 +30,7 @@ func atomicCounterIncrement(n *corev1.Node) {
 			panic(err)
 		}
 	}
+
 	n.Annotations[counterAnno] = strconv.Itoa(i + 1)
 }
 
@@ -62,10 +65,10 @@ func TestUpdateNodeRetryHandlesConflict(t *testing.T) {
 	)
 
 	err := UpdateNodeRetry(mockNi, "mock_node", atomicCounterIncrement)
-
 	if err != nil {
 		t.Errorf("unexpected error: expected increment to succeed")
 	}
+
 	if mockNode.Annotations["counter"] != "22" {
 		t.Errorf("expected the counter to hit 22; was %v", mockNode.Annotations["counter"])
 	}

--- a/pkg/k8sutil/pods.go
+++ b/pkg/k8sutil/pods.go
@@ -7,6 +7,8 @@ import (
 // FilterPods filters given list of pods using given function.
 func FilterPods(pods []corev1.Pod, filter func(*corev1.Pod) bool) (newpods []corev1.Pod) {
 	for _, p := range pods {
+		p := p
+
 		if filter(&p) {
 			newpods = append(newpods, p)
 		}

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -44,7 +44,7 @@ var DefaultBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
-// RetryConflict executes the provided function repeatedly, retrying if the server returns a conflicting
+// RetryOnConflict executes the provided function repeatedly, retrying if the server returns a conflicting
 // write. Callers should preserve previous executions if they wish to retry changes. It performs an
 // exponential backoff.
 //

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -85,7 +85,7 @@ func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
 	return err
 }
 
-// RetryOnError retries a function repeatedly with the specified backoff until it succeeds or times out
+// RetryOnError retries a function repeatedly with the specified backoff until it succeeds or times out.
 func RetryOnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
 

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -62,27 +62,33 @@ var DefaultBackoff = wait.Backoff{
 // TODO: Make Backoff an interface?
 func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
 	var lastConflictErr error
+
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		err := fn()
+
 		switch {
 		case err == nil:
 			return true, nil
 		case errors.IsConflict(err):
 			lastConflictErr = err
+
 			return false, nil
 		default:
 			return false, err
 		}
 	})
+
 	if err == wait.ErrWaitTimeout {
 		err = lastConflictErr
 	}
+
 	return err
 }
 
 // RetryOnError retries a function repeatedly with the specified backoff until it succeeds or times out
 func RetryOnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
+
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lastErr := fn()
 
@@ -92,5 +98,6 @@ func RetryOnError(backoff wait.Backoff, fn func() error) error {
 	if err == wait.ErrWaitTimeout {
 		err = lastErr
 	}
+
 	return err
 }

--- a/pkg/k8sutil/selector.go
+++ b/pkg/k8sutil/selector.go
@@ -16,6 +16,7 @@ func NewRequirementOrDie(key string, op selection.Operator, vals []string) *labe
 	if err != nil {
 		panic(err)
 	}
+
 	return req
 }
 
@@ -43,6 +44,7 @@ func FilterNodesByRequirement(nodes []corev1.Node, req *labels.Requirement) []co
 			matches = append(matches, node)
 		}
 	}
+
 	return matches
 }
 

--- a/pkg/operator/agent_manager.go
+++ b/pkg/operator/agent_manager.go
@@ -25,12 +25,12 @@ var (
 		"app":        agentDefaultAppName,
 	}
 
-	// Labels nodes where update-agent should be scheduled
+	// Labels nodes where update-agent should be scheduled.
 	enableUpdateAgentLabel = map[string]string{
 		constants.LabelUpdateAgentEnabled: constants.True,
 	}
 
-	// Label Requirement matching nodes which lack the update agent label
+	// Label Requirement matching nodes which lack the update agent label.
 	updateAgentLabelMissing = k8sutil.NewRequirementOrDie(
 		constants.LabelUpdateAgentEnabled,
 		selection.DoesNotExist,
@@ -56,9 +56,9 @@ func (k *Kontroller) legacyLabeler() {
 		return
 	}
 
-	// match nodes that don't have an update-agent label
+	// Match nodes that don't have an update-agent label.
 	nodesMissingLabel := k8sutil.FilterNodesByRequirement(nodelist.Items, updateAgentLabelMissing)
-	// match nodes that identify as Flatcar Container Linux
+	// Match nodes that identify as Flatcar Container Linux.
 	nodesToLabel := k8sutil.FilterContainerLinuxNodes(nodesMissingLabel)
 
 	klog.V(6).Infof("Found Flatcar Container Linux nodes to label: %+v", nodelist.Items)
@@ -72,7 +72,7 @@ func (k *Kontroller) legacyLabeler() {
 	}
 }
 
-// updateAgent updates the agent on nodes if necessary.
+// runDaemonsetUpdate updates the agent on nodes if necessary.
 //
 // NOTE: the version for the agent is assumed to match the versioning scheme
 // for the operator, thus our version is used to figure out the appropriate
@@ -88,7 +88,7 @@ func (k *Kontroller) runDaemonsetUpdate(agentImageRepo string) error {
 	}
 
 	if len(agentDaemonsets.Items) == 0 {
-		// No daemonset, create it
+		// No daemonset, create it.
 		runErr := k.createAgentDamonset(agentImageRepo)
 		if runErr != nil {
 			return runErr
@@ -123,7 +123,8 @@ func (k *Kontroller) runDaemonsetUpdate(agentImageRepo string) error {
 	}
 
 	if dsSemver.LT(version.Semver) {
-		// daemonset is too old, update it
+		// Daemonset is too old, update it.
+		//
 		// TODO: perform a proper rolling update rather than delete-then-recreate
 		// Right now, daemonset rolling updates aren't upstream and are thus fairly
 		// painful to do correctly. In addition, doing it correctly doesn't add too
@@ -131,7 +132,7 @@ func (k *Kontroller) runDaemonsetUpdate(agentImageRepo string) error {
 		falseVal := false
 
 		err := k.kc.AppsV1().DaemonSets(k.namespace).Delete(context.TODO(), agentDS.Name, metav1.DeleteOptions{
-			OrphanDependents: &falseVal, // Cascading delete
+			OrphanDependents: &falseVal, // Cascading delete.
 		})
 		if err != nil {
 			klog.Errorf("could not delete old daemonset %+v: %v", agentDS, err)
@@ -189,7 +190,7 @@ func agentDaemonsetSpec(repo string) *appsv1.DaemonSet {
 					},
 				},
 				Spec: corev1.PodSpec{
-					// Update the master nodes too
+					// Update the master nodes too.
 					Tolerations: []corev1.Toleration{
 						{
 							Key:      "node-role.kubernetes.io/master",

--- a/pkg/operator/agent_manager.go
+++ b/pkg/operator/agent_manager.go
@@ -84,14 +84,13 @@ func (k *Kontroller) runDaemonsetUpdate(agentImageRepo string) error {
 		LabelSelector: labels.SelectorFromSet(labels.Set(managedByOperatorLabels)).String(),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("listing DaemonSets: %w", err)
 	}
 
 	if len(agentDaemonsets.Items) == 0 {
 		// No daemonset, create it.
-		runErr := k.createAgentDamonset(agentImageRepo)
-		if runErr != nil {
-			return runErr
+		if err := k.createAgentDamonset(agentImageRepo); err != nil {
+			return fmt.Errorf("creating agent DaemonSet: %w", err)
 		}
 		// runAgent succeeded, all should be well and converging now
 		return nil
@@ -137,14 +136,14 @@ func (k *Kontroller) runDaemonsetUpdate(agentImageRepo string) error {
 		if err != nil {
 			klog.Errorf("could not delete old daemonset %+v: %v", agentDS, err)
 
-			return err
+			return fmt.Errorf("deleting old DaemonSet: %w", err)
 		}
 
 		err = k.createAgentDamonset(agentImageRepo)
 		if err != nil {
 			klog.Errorf("could not create new daemonset: %v", err)
 
-			return err
+			return fmt.Errorf("creating agent DaemonSet: %w", err)
 		}
 	}
 
@@ -156,7 +155,7 @@ func (k *Kontroller) createAgentDamonset(agentImageRepo string) error {
 
 	_, err := dsc.Create(context.TODO(), agentDaemonsetSpec(agentImageRepo), metav1.CreateOptions{})
 
-	return err
+	return err //nolint:wrapcheck
 }
 
 //nolint:funlen

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -133,7 +133,7 @@ type Config struct {
 func New(config Config) (*Kontroller, error) {
 	// kubernetes client
 	if config.Client == nil {
-		return nil, fmt.Errorf("Kubernetes client must not be nil")
+		return nil, fmt.Errorf("kubernetes client must not be nil")
 	}
 
 	kc := config.Client
@@ -175,7 +175,7 @@ func New(config Config) (*Kontroller, error) {
 	if config.RebootWindowStart != "" && config.RebootWindowLength != "" {
 		rw, err := timeutil.ParsePeriodic(config.RebootWindowStart, config.RebootWindowLength)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing reboot window: %s", err)
+			return nil, fmt.Errorf("parsing reboot window: %s", err)
 		}
 
 		rebootWindow = rw
@@ -361,7 +361,7 @@ func (k *Kontroller) process() {
 func (k *Kontroller) cleanupState() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %v", err)
 	}
 
 	for _, n := range nodelist.Items {
@@ -380,7 +380,7 @@ func (k *Kontroller) cleanupState() error {
 			}
 		})
 		if err != nil {
-			return fmt.Errorf("Failed to cleanup node %q: %v", n.Name, err)
+			return fmt.Errorf("cleaning up node %q: %v", n.Name, err)
 		}
 	}
 
@@ -398,7 +398,7 @@ func (k *Kontroller) cleanupState() error {
 func (k *Kontroller) checkBeforeReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %v", err)
 	}
 
 	preRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, beforeRebootReq)
@@ -418,7 +418,7 @@ func (k *Kontroller) checkBeforeReboot() error {
 				node.Annotations[constants.AnnotationOkToReboot] = constants.True
 			})
 			if err != nil {
-				return fmt.Errorf("Failed to update node %q: %v", n.Name, err)
+				return fmt.Errorf("updating node %q: %v", n.Name, err)
 			}
 		}
 	}
@@ -435,7 +435,7 @@ func (k *Kontroller) checkBeforeReboot() error {
 func (k *Kontroller) checkAfterReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %v", err)
 	}
 
 	postRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, afterRebootReq)
@@ -455,7 +455,7 @@ func (k *Kontroller) checkAfterReboot() error {
 				node.Annotations[constants.AnnotationOkToReboot] = constants.False
 			})
 			if err != nil {
-				return fmt.Errorf("Failed to update node %q: %v", n.Name, err)
+				return fmt.Errorf("updating node %q: %v", n.Name, err)
 			}
 		}
 	}
@@ -476,7 +476,7 @@ func (k *Kontroller) checkAfterReboot() error {
 func (k *Kontroller) markBeforeReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %v", err)
 	}
 
 	// check if a reboot window is configured
@@ -534,7 +534,7 @@ func (k *Kontroller) markBeforeReboot() error {
 	for _, n := range chosenNodes {
 		err = k.mark(n.Name, constants.LabelBeforeReboot, k.beforeRebootAnnotations)
 		if err != nil {
-			return fmt.Errorf("Failed to label node for before reboot checks: %v", err)
+			return fmt.Errorf("labeling node for before reboot checks: %v", err)
 		}
 
 		if len(k.beforeRebootAnnotations) > 0 {
@@ -556,7 +556,7 @@ func (k *Kontroller) markBeforeReboot() error {
 func (k *Kontroller) markAfterReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %v", err)
 	}
 
 	// find nodes which just rebooted
@@ -570,7 +570,7 @@ func (k *Kontroller) markAfterReboot() error {
 	for _, n := range justRebootedNodes {
 		err = k.mark(n.Name, constants.LabelAfterReboot, k.afterRebootAnnotations)
 		if err != nil {
-			return fmt.Errorf("Failed to label node for after reboot checks: %v", err)
+			return fmt.Errorf("labeling node for after reboot checks: %v", err)
 		}
 
 		if len(k.afterRebootAnnotations) > 0 {
@@ -592,7 +592,7 @@ func (k *Kontroller) mark(nodeName string, label string, annotations []string) e
 		node.Labels[label] = constants.True
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to set %q to %q on node %q: %v", label, constants.True, nodeName, err)
+		return fmt.Errorf("setting label %q to %q on node %q: %v", label, constants.True, nodeName, err)
 	}
 
 	return nil

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,3 +1,4 @@
+// Package operator contains main implementation of Flatcar Linux Update Operator.
 package operator
 
 import (

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -36,9 +36,9 @@ const (
 
 	leaderElectionResourceName = "flatcar-linux-update-operator-lock"
 
-	// Arbitrarily copied from KVO
+	// Arbitrarily copied from KVO.
 	leaderElectionLease = 90 * time.Second
-	// ReconciliationPeriod
+	// ReconciliationPeriod.
 	reconciliationPeriod = 30 * time.Second
 )
 
@@ -68,19 +68,19 @@ var (
 		"," + constants.AnnotationRebootInProgress + "!=" + constants.True)
 
 	// stillRebootingSelector is a selector for the annotation set expected to be
-	// on a node when it's in the process of rebooting
+	// on a node when it's in the process of rebooting.
 	stillRebootingSelector = fields.Set(map[string]string{
 		constants.AnnotationOkToReboot:   constants.True,
 		constants.AnnotationRebootNeeded: constants.True,
 	}).AsSelector()
 
-	// beforeRebootReq requires a node to be waiting for before reboot checks to complete
+	// beforeRebootReq requires a node to be waiting for before reboot checks to complete.
 	beforeRebootReq = k8sutil.NewRequirementOrDie(constants.LabelBeforeReboot, selection.In, []string{constants.True})
 
-	// afterRebootReq requires a node to be waiting for after reboot checks to complete
+	// afterRebootReq requires a node to be waiting for after reboot checks to complete.
 	afterRebootReq = k8sutil.NewRequirementOrDie(constants.LabelAfterReboot, selection.In, []string{constants.True})
 
-	// notBeforeRebootReq and notAfterRebootReq are the inverse of the above checks
+	// notBeforeRebootReq and notAfterRebootReq are the inverse of the above checks.
 	notBeforeRebootReq = k8sutil.NewRequirementOrDie(constants.LabelBeforeReboot, selection.NotIn, []string{constants.True})
 	notAfterRebootReq  = k8sutil.NewRequirementOrDie(constants.LabelAfterReboot, selection.NotIn, []string{constants.True})
 )
@@ -90,58 +90,58 @@ type Kontroller struct {
 	nc corev1client.NodeInterface
 	er record.EventRecorder
 
-	// annotations to look for before and after reboots
+	// Annotations to look for before and after reboots.
 	beforeRebootAnnotations []string
 	afterRebootAnnotations  []string
 
 	leaderElectionClient        *kubernetes.Clientset
 	leaderElectionEventRecorder record.EventRecorder
-	// namespace is the kubernetes namespace any resources (e.g. locks,
+	// Namespace is the kubernetes namespace any resources (e.g. locks,
 	// configmaps, agents) should be created and read under.
 	// It will be set to the namespace the operator is running in automatically.
 	namespace string
 
-	// auto-label Flatcar Container Linux nodes for migration compatibility
+	// Auto-label Flatcar Container Linux nodes for migration compatibility.
 	autoLabelContainerLinux bool
 
-	// reboot window
+	// Reboot window.
 	rebootWindow *timeutil.Periodic
 
-	// Deprecated
+	// Deprecated.
 	manageAgent    bool
 	agentImageRepo string
 }
 
 // Config configures a Kontroller.
 type Config struct {
-	// Kubernetesc client
+	// Kubernetes client.
 	Client kubernetes.Interface
-	// migration compatibility
+	// Migration compatibility.
 	AutoLabelContainerLinux bool
-	// annotations to look for before and after reboots
+	// Annotations to look for before and after reboots.
 	BeforeRebootAnnotations []string
 	AfterRebootAnnotations  []string
-	// reboot window
+	// Reboot window.
 	RebootWindowStart  string
 	RebootWindowLength string
-	// Deprecated
+	// Deprecated.
 	ManageAgent    bool
 	AgentImageRepo string
 }
 
 // New initializes a new Kontroller.
 func New(config Config) (*Kontroller, error) {
-	// kubernetes client
+	// Kubernetes client.
 	if config.Client == nil {
 		return nil, fmt.Errorf("kubernetes client must not be nil")
 	}
 
 	kc := config.Client
 
-	// node interface
+	// Node interface.
 	nc := kc.CoreV1().Nodes()
 
-	// create event emitter
+	// Create event emitter.
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: kc.CoreV1().Events("")})
 	er := broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: eventSourceComponent})
@@ -205,7 +205,7 @@ func (k *Kontroller) Run(stop <-chan struct{}) error {
 		return err
 	}
 
-	// start Flatcar Container Linux node auto-labeler
+	// Start Flatcar Container Linux node auto-labeler.
 	if k.autoLabelContainerLinux {
 		go wait.Until(k.legacyLabeler, reconciliationPeriod, stop)
 	}
@@ -213,7 +213,7 @@ func (k *Kontroller) Run(stop <-chan struct{}) error {
 	// Before doing anything else, make sure the associated agent daemonset is
 	// ready if it's our responsibility.
 	if k.manageAgent && k.agentImageRepo != "" {
-		// create or update the update-agent daemonset
+		// Create or update the update-agent daemonset.
 		err := k.runDaemonsetUpdate(k.agentImageRepo)
 		if err != nil {
 			klog.Errorf("unable to ensure managed agents are ready: %v", err)
@@ -224,7 +224,7 @@ func (k *Kontroller) Run(stop <-chan struct{}) error {
 
 	klog.V(5).Info("starting controller")
 
-	// call the process loop each period, until stop is closed
+	// Call the process loop each period, until stop is closed.
 	wait.Until(k.process, reconciliationPeriod, stop)
 
 	klog.V(5).Info("stopping controller")
@@ -233,7 +233,7 @@ func (k *Kontroller) Run(stop <-chan struct{}) error {
 }
 
 // withLeaderElection creates a new context which is cancelled when this
-// operator does not hold a lock to operate on the cluster
+// operator does not hold a lock to operate on the cluster.
 func (k *Kontroller) withLeaderElection() error {
 	// TODO: a better id might be necessary.
 	// Currently, KVO uses env.POD_NAME and the upstream controller-manager uses this.
@@ -293,7 +293,7 @@ func (k *Kontroller) withLeaderElection() error {
 func (k *Kontroller) process() {
 	klog.V(4).Info("Going through a loop cycle")
 
-	// first make sure that all of our nodes are in a well-defined state with
+	// First make sure that all of our nodes are in a well-defined state with
 	// respect to our annotations and labels, and if they are not, then try to
 	// fix them.
 	klog.V(4).Info("Cleaning up node state")
@@ -305,7 +305,7 @@ func (k *Kontroller) process() {
 		return
 	}
 
-	// find nodes with the after-reboot=true label and check if all provided
+	// Find nodes with the after-reboot=true label and check if all provided
 	// annotations are set. if all annotations are set to true then remove the
 	// after-reboot=true label and set reboot-ok=false, telling the agent that
 	// the reboot has completed.
@@ -318,7 +318,7 @@ func (k *Kontroller) process() {
 		return
 	}
 
-	// find nodes which just rebooted but haven't run after-reboot checks.
+	// Find nodes which just rebooted but haven't run after-reboot checks.
 	// remove after-reboot annotations and add the after-reboot=true label.
 	klog.V(4).Info("Labeling rebooted nodes with after-reboot label")
 
@@ -329,7 +329,7 @@ func (k *Kontroller) process() {
 		return
 	}
 
-	// find nodes with the before-reboot=true label and check if all provided
+	// Find nodes with the before-reboot=true label and check if all provided
 	// annotations are set. if all annotations are set to true then remove the
 	// before-reboot=true label and set reboot=ok=true, telling the agent it's
 	// time to reboot.
@@ -342,7 +342,7 @@ func (k *Kontroller) process() {
 		return
 	}
 
-	// take some number of the rebootable nodes. remove before-reboot
+	// Take some number of the rebootable nodes. remove before-reboot
 	// annotations and add the before-reboot=true label.
 	klog.V(4).Info("Labeling rebootable nodes with before-reboot label")
 
@@ -366,8 +366,8 @@ func (k *Kontroller) cleanupState() error {
 
 	for _, n := range nodelist.Items {
 		err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *corev1.Node) {
-			// make sure that nodes with the before-reboot label actually
-			// still wants to reboot
+			// Make sure that nodes with the before-reboot label actually
+			// still wants to reboot.
 			if _, exists := node.Labels[constants.LabelBeforeReboot]; exists {
 				if !wantsRebootSelector.Matches(fields.Set(node.Annotations)) {
 					klog.Warningf("Node %v no longer wanted to reboot while we were trying to label it so: %v",
@@ -410,7 +410,7 @@ func (k *Kontroller) checkBeforeReboot() error {
 
 			err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *corev1.Node) {
 				delete(node.Labels, constants.LabelBeforeReboot)
-				// cleanup the before-reboot annotations
+				// Cleanup the before-reboot annotations.
 				for _, annotation := range k.beforeRebootAnnotations {
 					klog.V(4).Infof("Deleting annotation %q from node %q", annotation, node.Name)
 					delete(node.Annotations, annotation)
@@ -447,7 +447,7 @@ func (k *Kontroller) checkAfterReboot() error {
 
 			err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *corev1.Node) {
 				delete(node.Labels, constants.LabelAfterReboot)
-				// cleanup the after-reboot annotations
+				// Cleanup the after-reboot annotations.
 				for _, annotation := range k.afterRebootAnnotations {
 					klog.V(4).Infof("Deleting annotation %q from node %q", annotation, node.Name)
 					delete(node.Annotations, annotation)
@@ -479,11 +479,11 @@ func (k *Kontroller) markBeforeReboot() error {
 		return fmt.Errorf("listing nodes: %w", err)
 	}
 
-	// check if a reboot window is configured
+	// Check if a reboot window is configured.
 	if k.rebootWindow != nil {
-		// get previous occurrence relative to now
+		// Get previous occurrence relative to now.
 		period := k.rebootWindow.Previous(time.Now())
-		// check if we are inside the reboot window
+		// Check if we are inside the reboot window.
 		if !(period.End.After(time.Now())) {
 			klog.V(4).Info("We are outside the reboot window; not labeling rebootable nodes for now")
 
@@ -491,15 +491,15 @@ func (k *Kontroller) markBeforeReboot() error {
 		}
 	}
 
-	// find nodes which are still rebooting
+	// Find nodes which are still rebooting.
 	rebootingNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, stillRebootingSelector)
-	// nodes running before and after reboot checks are still considered to be "rebooting" to us
+	// Nodes running before and after reboot checks are still considered to be "rebooting" to us.
 	beforeRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, beforeRebootReq)
 	rebootingNodes = append(rebootingNodes, beforeRebootNodes...)
 	afterRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, afterRebootReq)
 	rebootingNodes = append(rebootingNodes, afterRebootNodes...)
 
-	// Verify the number of currently rebooting nodes is less than the the maximum number
+	// Verify the number of currently rebooting nodes is less than the the maximum number.
 	if len(rebootingNodes) >= maxRebootingNodes {
 		for _, n := range rebootingNodes {
 			klog.Infof("Found node %q still rebooting, waiting", n.Name)
@@ -510,7 +510,7 @@ func (k *Kontroller) markBeforeReboot() error {
 		return nil
 	}
 
-	// find nodes which want to reboot
+	// Find nodes which want to reboot.
 	rebootableNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, wantsRebootSelector)
 	rebootableNodes = k8sutil.FilterNodesByRequirement(rebootableNodes, notBeforeRebootReq)
 
@@ -519,16 +519,16 @@ func (k *Kontroller) markBeforeReboot() error {
 		return nil
 	}
 
-	// find the number of nodes we can tell to reboot
+	// Find the number of nodes we can tell to reboot.
 	remainingRebootableCount := maxRebootingNodes - len(rebootingNodes)
 
-	// choose some number of nodes
+	// Choose some number of nodes.
 	chosenNodes := make([]*corev1.Node, 0, remainingRebootableCount)
 	for i := 0; i < remainingRebootableCount && i < len(rebootableNodes); i++ {
 		chosenNodes = append(chosenNodes, &rebootableNodes[i])
 	}
 
-	// set before-reboot=true for the chosen nodes
+	// Set before-reboot=true for the chosen nodes.
 	klog.Infof("Found %d nodes that need a reboot", len(chosenNodes))
 
 	for _, n := range chosenNodes {
@@ -559,14 +559,14 @@ func (k *Kontroller) markAfterReboot() error {
 		return fmt.Errorf("listing nodes: %w", err)
 	}
 
-	// find nodes which just rebooted
+	// Find nodes which just rebooted.
 	justRebootedNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, justRebootedSelector)
-	// also filter out any nodes that are already labeled with after-reboot=true
+	// Also filter out any nodes that are already labeled with after-reboot=true.
 	justRebootedNodes = k8sutil.FilterNodesByRequirement(justRebootedNodes, notAfterRebootReq)
 
 	klog.Infof("Found %d rebooted nodes", len(justRebootedNodes))
 
-	// for all the nodes which just rebooted, remove any old annotations and add the after-reboot=true label
+	// For all the nodes which just rebooted, remove any old annotations and add the after-reboot=true label.
 	for _, n := range justRebootedNodes {
 		err = k.mark(n.Name, constants.LabelAfterReboot, k.afterRebootAnnotations)
 		if err != nil {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -148,12 +148,12 @@ func New(config Config) (*Kontroller, error) {
 
 	leaderElectionClientConfig, err := rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error creating leader election client config: %v", err)
+		return nil, fmt.Errorf("error creating leader election client config: %w", err)
 	}
 
 	leaderElectionClient, err := kubernetes.NewForConfig(leaderElectionClientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error creating leader election client: %v", err)
+		return nil, fmt.Errorf("error creating leader election client: %w", err)
 	}
 
 	leaderElectionBroadcaster := record.NewBroadcaster()
@@ -175,7 +175,7 @@ func New(config Config) (*Kontroller, error) {
 	if config.RebootWindowStart != "" && config.RebootWindowLength != "" {
 		rw, err := timeutil.ParsePeriodic(config.RebootWindowStart, config.RebootWindowLength)
 		if err != nil {
-			return nil, fmt.Errorf("parsing reboot window: %s", err)
+			return nil, fmt.Errorf("parsing reboot window: %w", err)
 		}
 
 		rebootWindow = rw
@@ -361,7 +361,7 @@ func (k *Kontroller) process() {
 func (k *Kontroller) cleanupState() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %w", err)
 	}
 
 	for _, n := range nodelist.Items {
@@ -380,7 +380,7 @@ func (k *Kontroller) cleanupState() error {
 			}
 		})
 		if err != nil {
-			return fmt.Errorf("cleaning up node %q: %v", n.Name, err)
+			return fmt.Errorf("cleaning up node %q: %w", n.Name, err)
 		}
 	}
 
@@ -398,7 +398,7 @@ func (k *Kontroller) cleanupState() error {
 func (k *Kontroller) checkBeforeReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %w", err)
 	}
 
 	preRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, beforeRebootReq)
@@ -418,7 +418,7 @@ func (k *Kontroller) checkBeforeReboot() error {
 				node.Annotations[constants.AnnotationOkToReboot] = constants.True
 			})
 			if err != nil {
-				return fmt.Errorf("updating node %q: %v", n.Name, err)
+				return fmt.Errorf("updating node %q: %w", n.Name, err)
 			}
 		}
 	}
@@ -435,7 +435,7 @@ func (k *Kontroller) checkBeforeReboot() error {
 func (k *Kontroller) checkAfterReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %w", err)
 	}
 
 	postRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, afterRebootReq)
@@ -455,7 +455,7 @@ func (k *Kontroller) checkAfterReboot() error {
 				node.Annotations[constants.AnnotationOkToReboot] = constants.False
 			})
 			if err != nil {
-				return fmt.Errorf("updating node %q: %v", n.Name, err)
+				return fmt.Errorf("updating node %q: %w", n.Name, err)
 			}
 		}
 	}
@@ -476,7 +476,7 @@ func (k *Kontroller) checkAfterReboot() error {
 func (k *Kontroller) markBeforeReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %w", err)
 	}
 
 	// check if a reboot window is configured
@@ -534,7 +534,7 @@ func (k *Kontroller) markBeforeReboot() error {
 	for _, n := range chosenNodes {
 		err = k.mark(n.Name, constants.LabelBeforeReboot, k.beforeRebootAnnotations)
 		if err != nil {
-			return fmt.Errorf("labeling node for before reboot checks: %v", err)
+			return fmt.Errorf("labeling node for before reboot checks: %w", err)
 		}
 
 		if len(k.beforeRebootAnnotations) > 0 {
@@ -556,7 +556,7 @@ func (k *Kontroller) markBeforeReboot() error {
 func (k *Kontroller) markAfterReboot() error {
 	nodelist, err := k.nc.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("listing nodes: %v", err)
+		return fmt.Errorf("listing nodes: %w", err)
 	}
 
 	// find nodes which just rebooted
@@ -570,7 +570,7 @@ func (k *Kontroller) markAfterReboot() error {
 	for _, n := range justRebootedNodes {
 		err = k.mark(n.Name, constants.LabelAfterReboot, k.afterRebootAnnotations)
 		if err != nil {
-			return fmt.Errorf("labeling node for after reboot checks: %v", err)
+			return fmt.Errorf("labeling node for after reboot checks: %w", err)
 		}
 
 		if len(k.afterRebootAnnotations) > 0 {
@@ -592,7 +592,7 @@ func (k *Kontroller) mark(nodeName string, label string, annotations []string) e
 		node.Labels[label] = constants.True
 	})
 	if err != nil {
-		return fmt.Errorf("setting label %q to %q on node %q: %v", label, constants.True, nodeName, err)
+		return fmt.Errorf("setting label %q to %q on node %q: %w", label, constants.True, nodeName, err)
 	}
 
 	return nil

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -241,7 +241,7 @@ func (k *Kontroller) withLeaderElection() error {
 	// more likely to have a value.
 	id, err := os.Hostname()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting hostname: %w", err)
 	}
 
 	resLock := &resourcelock.ConfigMapLock{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	eventReasonRebootFailed            = "RebootFailed"
 	eventSourceComponent               = "update-operator"
 	leaderElectionEventSourceComponent = "update-operator-leader-election"
 	// agentDefaultAppName is the label value for the 'app' key that agents are

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -38,6 +38,7 @@ type Client struct {
 
 func New() (*Client, error) {
 	c := new(Client)
+
 	var err error
 
 	c.conn, err = dbus.SystemBusPrivate()
@@ -46,15 +47,18 @@ func New() (*Client, error) {
 	}
 
 	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
+
 	err = c.conn.Auth(methods)
 	if err != nil {
 		c.conn.Close()
+
 		return nil, err
 	}
 
 	err = c.conn.Hello()
 	if err != nil {
 		c.conn.Close()
+
 		return nil, err
 	}
 
@@ -78,6 +82,7 @@ func (c *Client) Close() error {
 	if c.conn != nil {
 		return c.conn.Close()
 	}
+
 	return nil
 }
 
@@ -121,6 +126,7 @@ func (c *Client) GetStatus() (Status, error) {
 	if call.Err != nil {
 		return Status{}, call.Err
 	}
+
 	return NewStatus(call.Body), nil
 }
 
@@ -128,5 +134,6 @@ func (c *Client) GetStatus() (Status, error) {
 // call - it returns immediately.
 func (c *Client) AttemptUpdate() error {
 	call := c.object.Call(dbusInterface+".AttemptUpdate", 0)
+
 	return call.Err
 }

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -23,11 +23,10 @@ import (
 )
 
 const (
-	dbusPath            = "/com/coreos/update1"
-	dbusInterface       = "com.coreos.update1.Manager"
-	dbusMember          = "StatusUpdate"
-	dbusMemberInterface = dbusInterface + "." + dbusMember
-	signalBuffer        = 32 // TODO(bp): What is a reasonable value here?
+	dbusPath      = "/com/coreos/update1"
+	dbusInterface = "com.coreos.update1.Manager"
+	dbusMember    = "StatusUpdate"
+	signalBuffer  = 32 // TODO(bp): What is a reasonable value here?
 )
 
 type Client struct {

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -128,11 +128,3 @@ func (c *Client) GetStatus() (Status, error) {
 
 	return NewStatus(call.Body), nil
 }
-
-// AttemptUpdate will trigger an update if available. This is an asynchronous
-// call - it returns immediately.
-func (c *Client) AttemptUpdate() error {
-	call := c.object.Call(dbusInterface+".AttemptUpdate", 0)
-
-	return call.Err
-}

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -92,7 +92,7 @@ func (c *Client) Close() error {
 func (c *Client) ReceiveStatuses(rcvr chan Status, stop <-chan struct{}) {
 	// if there is an error getting the current status, ignore it and just
 	// move onto the main loop.
-	st, _ := c.GetStatus()
+	st, _ := c.getStatus()
 	rcvr <- st
 
 	for {
@@ -119,8 +119,8 @@ func (c *Client) RebootNeededSignal(rcvr chan Status, stop <-chan struct{}) {
 	}
 }
 
-// GetStatus gets the current status from update_engine
-func (c *Client) GetStatus() (Status, error) {
+// getStatus gets the current status from update_engine
+func (c *Client) getStatus() (Status, error) {
 	call := c.object.Call(dbusInterface+".GetStatus", 0)
 	if call.Err != nil {
 		return Status{}, call.Err

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -42,7 +42,7 @@ func New() (*Client, error) {
 
 	c.conn, err = dbus.SystemBusPrivate()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("opening private connection to system bus: %w", err)
 	}
 
 	methods := []dbus.Auth{dbus.AuthExternal(strconv.Itoa(os.Getuid()))}
@@ -51,14 +51,14 @@ func New() (*Client, error) {
 	if err != nil {
 		c.conn.Close()
 
-		return nil, err
+		return nil, fmt.Errorf("authenticating to system bus: %w", err)
 	}
 
 	err = c.conn.Hello()
 	if err != nil {
 		c.conn.Close()
 
-		return nil, err
+		return nil, fmt.Errorf("sending hello to system bus: %w", err)
 	}
 
 	c.object = c.conn.Object("com.coreos.update1", dbus.ObjectPath(dbusPath))

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -63,7 +63,7 @@ func New() (*Client, error) {
 
 	c.object = c.conn.Object("com.coreos.update1", dbus.ObjectPath(dbusPath))
 
-	// Setup the filter for the StatusUpdate signals
+	// Setup the filter for the StatusUpdate signals.
 	match := fmt.Sprintf("type='signal',interface='%s',member='%s'", dbusInterface, dbusMember)
 
 	call := c.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
@@ -90,7 +90,7 @@ func (c *Client) Close() error {
 // get the initial status and send it on the rcvr channel before receiving
 // starts.
 func (c *Client) ReceiveStatuses(rcvr chan Status, stop <-chan struct{}) {
-	// if there is an error getting the current status, ignore it and just
+	// If there is an error getting the current status, ignore it and just
 	// move onto the main loop.
 	st, _ := c.getStatus()
 	rcvr <- st
@@ -119,7 +119,7 @@ func (c *Client) RebootNeededSignal(rcvr chan Status, stop <-chan struct{}) {
 	}
 }
 
-// getStatus gets the current status from update_engine
+// getStatus gets the current status from update_engine.
 func (c *Client) getStatus() (Status, error) {
 	call := c.object.Call(dbusInterface+".GetStatus", 0)
 	if call.Err != nil {

--- a/pkg/updateengine/client_test.go
+++ b/pkg/updateengine/client_test.go
@@ -50,9 +50,12 @@ func TestRebootNeededSignal(t *testing.T) {
 	}
 	r := make(chan Status)
 	s := make(chan struct{})
+
 	var done bool
+
 	go func() {
 		c.RebootNeededSignal(r, s)
+
 		done = true
 	}()
 
@@ -60,6 +63,7 @@ func TestRebootNeededSignal(t *testing.T) {
 		t.Fatal("RebootNeededSignal stopped prematurely")
 	}
 	c.ch <- makeSig(UpdateStatusUpdatedNeedReboot)
+
 	if done {
 		t.Fatal("RebootNeededSignal stopped prematurely")
 	}

--- a/pkg/updateengine/doc.go
+++ b/pkg/updateengine/doc.go
@@ -1,0 +1,3 @@
+// Package updateengine provides an interface for communicating with
+// update_engine via D-BUS interface on the host.
+package updateengine

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,6 +26,7 @@ func init() {
 		klog.Fatalf("invalid build of update operator; version.Version must be set at compile "+
 			"time to a valid semver value. %v could not parse: %v", Version, err)
 	}
+
 	Semver = v
 }
 


### PR DESCRIPTION
Before:
```sh
$ golangci-lint run ./... | grep -E \*.go: | rev | awk '{print $1}' | rev | sort | uniq -c | sort -h
      1 (exhaustive)
      1 (gochecknoinits)
      1 (goimports)
      1 (gosimple)
      1 (maligned)
      1 (whitespace)
      2 (deadcode)
      2 (dupl)
      2 (gocritic)
      2 (gofumpt)
      2 (scopelint)
      2 (testpackage)
      4 (funlen)
      9 (errcheck)
     10 (gomnd)
     13 (stylecheck)
     15 (lll)
     17 (wrapcheck)
     20 (godot)
     23 (nlreturn)
     25 (golint)
     36 (errorlint)
     82 (wsl)
```

After:
```sh
$ golangci-lint run ./... | grep -E \*.go: | rev | awk '{print $1}' | rev | sort | uniq -c | sort -h
      1 (exhaustive)
      1 (gochecknoinits)
      2 (dupl)
      2 (errorlint)
      2 (testpackage)
      5 (funlen)
      7 (errcheck)
     10 (gomnd)
     11 (golint)
     15 (lll)
```