### PR TITLE
README.md: mention rebooting nodes via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ kubectl apply -f examples/deploy -R
 ## Test
 
 To test that it is working, you can SSH to a node and trigger an update check by running `update_engine_client -check_for_update` or simulate a reboot is needed by running `locksmithctl send-need-reboot`.
+
+You can also annotate one of your nodes using the command below. Shortly after, you should see the Node being drained as a preparation for the reboot.
+
+```sh
+export NODE="<node name>"
+kubectl annotate node $NODE --overwrite \
+    flatcar-linux-update.v1.flatcar-linux.net/reboot-needed="true"
+```


### PR DESCRIPTION
It does not test integration with update_engine, but it's a handy trick
for scheduling a reboot for nodes without SSH.

Closes #57

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
