### PR TITLE
.github/workflows/release.yaml: initial commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: Build Docker images
+
+on:
+  push:
+    tags:
+    - v*
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: flatcar-linux/flatcar-linux-update-operator
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+    - name: Get tag name
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64/v8
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit adds a GitHub Actions release pipeline which initially will
just build Docker images when a version tag is pushed. We may consider
extending this pipeline in the future.

This will also provide ARM images as part of the future releases.

Closes #64
Closes #65

Co-authored-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>