### PR TITLE
pkg/agent: fix quotes handling

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -518,7 +518,9 @@ func splitNewlineEnv(envVars map[string]string, envs string) {
 			continue
 		}
 
-		envVars[spl[0]] = spl[1]
+		// Let's clear the value in case of quoting to get only the value
+		// e.g FOO="BAR" becomes 'FOO: BAR' (and not FOO: "BAR")
+		envVars[spl[0]] = strings.Trim(spl[1], "\"'")
 	}
 }
 

--- a/pkg/agent/agent_internal_test.go
+++ b/pkg/agent/agent_internal_test.go
@@ -10,6 +10,20 @@ import (
 func Test_splitNewlineEnv(t *testing.T) {
 	t.Parallel()
 
+	t.Run("handle_quoted_variables", func(t *testing.T) {
+		t.Parallel()
+
+		expected := map[string]string{"foo": "bar"}
+
+		input := map[string]string{}
+
+		splitNewlineEnv(input, `foo="bar"`)
+
+		if !reflect.DeepEqual(expected, input) {
+			t.Fatalf("Should handle quoted variables")
+		}
+	})
+
 	t.Run("retain_map_values_when_given_empty_input", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
In newer Flatcar versions, we started to follow the conventional bash variable spec:
```
FOO="BAR"
```

FLUO was handling this as '[FOO: "BAR"]' so it was failing to update Kubernetes nodes label, see[^1]:
> The name segment is required and must be 63 characters or less,
> beginning and ending with an alphanumeric character ([a-z0-9A-Z])
> with dashes (-), underscores (_), dots (.), and alphanumerics between.
> The prefix is optional. If specified, the prefix must be a DNS subdomain:
> a series of DNS labels separated by dots (.), not longer than
> 253 characters in total, followed by a slash (/).

[^1]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

In this change, we handle the quotes (simple and double) to get an '[FOO: BAR]' key/value from a FLUO point of view.

---

I did not test in an actual deployment but I confirmed on Flatcar instances:
* Current Stable:
```
$ cat /usr/share/flatcar/os-release
NAME="Flatcar Container Linux by Kinvolk"
ID=flatcar
ID_LIKE=coreos
VERSION=4593.2.2
VERSION_ID=4593.2.2
BUILD_ID=2026-05-26-1501
SYSEXT_LEVEL=1.0
PRETTY_NAME="Flatcar Container Linux by Kinvolk 4593.2.2 (Oklo)"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar.org/"
BUG_REPORT_URL="https://issues.flatcar.org"
FLATCAR_BOARD="amd64-usr"
CPE_NAME="cpe:2.3:o:flatcar-linux:flatcar_linux:4593.2.2:*:*:*:*:*:*:*"
```

* Current Beta:
```
$ cat /usr/share/flatcar/os-release
NAME="Flatcar Container Linux by Kinvolk"
ID="flatcar"
ID_LIKE="coreos"
VERSION="4694.1.0"
VERSION_ID="4694.1.0"
BUILD_ID="2026-06-15-0931"
SYSEXT_LEVEL="1.0"
PRETTY_NAME="Flatcar Container Linux by Kinvolk 4694.1.0"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar.org"
BUG_REPORT_URL="https://issues.flatcar.org"
SUPPORT_URL="https://groups.google.com/forum/#!forum/flatcar-linux-user"
FLATCAR_BOARD="amd64-usr"
CPE_NAME="cpe:2.3:o:flatcar-linux:flatcar_linux:4694.1.0:*:*:*:*:*:*:*"
```

And with a simple binary:
```go
package main

import (
	"os"
	"fmt"
	"bufio"
	"strings"
)

func main() {
	envVars := map[string]string{}
	b, _:= os.ReadFile("/usr/share/flatcar/os-release")
	sc := bufio.NewScanner(strings.NewReader(string(b)))
	for sc.Scan() {
		// Even if value contains the delimiter, we want to ignore it.
		maxSubstrings := 2
		spl := strings.SplitN(sc.Text(), "=", maxSubstrings)

		// Just skip empty lines or lines without a value.
		if len(spl) == 1 {
			continue
		}

		envVars[spl[0]] = strings.Trim(spl[1], "\"'")
	}

	fmt.Println(envVars["ID"])
	fmt.Println(envVars["VERSION"])
}
```
I have in both cases:
```
$ ./main
flatcar
4694.1.0
```

While before the change on Beta, it was showing:
```
$ ./main
"flatcar"
"4694.1.0"
```

This has been raised here: https://github.com/flatcar/Flatcar/issues/2176