### PR TITLE
.github/workflows: bump actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,31 +18,31 @@ jobs:
 
     - name: Get tag name
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         flavor: latest=false
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true


### PR DESCRIPTION
Those are mainly outdated and created errors, e.g[^1]:
```
ERROR: Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1": unknown:
```

[^1]: https://github.com/flatcar/flatcar-linux-update-operator/actions/runs/27956382863/job/82725782606

---

I'll retag [`v0.10.0-rc2`](https://github.com/flatcar/flatcar-linux-update-operator/releases/tag/v0.10.0-rc2) right after.